### PR TITLE
Use absolute path for dylib install_name

### DIFF
--- a/makefile.in
+++ b/makefile.in
@@ -96,7 +96,7 @@ libfec.a: $(LIBS)
 
 # for Darwin
 libfec.dylib: $(LIBS)
-	$(CC) -dynamiclib -install_name $@ -o $@ $^
+	$(CC) -dynamiclib -install_name @libdir@/$@ -o $@ $^
 
 # for Linux et al
 libfec.so: $(LIBS)


### PR DESCRIPTION
macOS requires that the install_name be the absolute path where the library will be installed (or be relative to something using `@executable_path`, `@loader_path` or `@rpath`, but those aren't usually appropriate for a general use case like this).